### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:8.1-apache
 
 RUN apt-get update && apt-get install -y \
 		libxml2-dev libmagickwand-dev git unzip
-RUN docker-php-ext-install soap
+RUN docker-php-ext-install soap pdo pdo_mysql
 RUN pecl install imagick && docker-php-ext-enable imagick
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,13 @@ services:
       - .:/var/www/html
     ports:
       - 8081:80
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_NAME: veloinfo
+      DB_USER: veloinfo
+      DB_PWD: veloinfo
+      RECPATCHA_SECRET: secret
   db:
     image: mysql
     volumes:
@@ -24,5 +31,13 @@ services:
       - ../veloinfo-web/:/app
     ports:
       - 3000:3000
+    environment:
+      REACT_APP_API_URL: /
+      REACT_APP_API_PROXY_URL: http://localhost:8081
+      REACT_APP_RECAPTCHA_V3_SITE_KEY: key
+      REACT_APP_JAWG_ID: ""
+      REACT_APP_JAWG_TOKEN: ""
+      API_IMPORT_KEY = ""volumes:
+  
 volumes:
   veloinfo-data:

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ if (!file_exists(__DIR__ . '/../.env')) {
 $dotenv->load();
 
 define("CUSTOM_LOGS", $_ENV['CUSTOM_LOGS'] ?? false);
+error_reporting(E_ERROR);
 
 /**
  * @todo refactor

--- a/schema.sql
+++ b/schema.sql
@@ -52,6 +52,8 @@ CREATE TABLE `contributions` (
   `issue_id` int unsigned DEFAULT NULL,
   `comment` text,
   `photo_path` varchar(256) DEFAULT NULL,
+  `photo_width` int unsigned DEFAULT NULL,
+  `photo_height` int unsigned DEFAULT NULL,
   `location` text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
   `user_id` int unsigned NOT NULL,
   `name` varchar(256) DEFAULT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE `users` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `user_id` varchar(256) DEFAULT NULL,
   `token` varchar(256) DEFAULT NULL,
+  `rq_ip`varchar(256) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/src/Models/DB.php
+++ b/src/Models/DB.php
@@ -22,7 +22,7 @@ class DB
                 'mysql:host=' . $host . ';dbname=' . $dbName . ';charset=utf8', $dbUser, $pwd
             );
         } catch (PDOException $e) {
-            die("error, please try again");
+            die("could not connect to the database".$e);
         }
     }
 


### PR DESCRIPTION
On peut maintenant démarrer l'application localement sans autre configuration que le recaptcha. Il faudrait le rendre optionnel. 

* Les variables d'environnement sont dans le docker-compose
* Ajout de champs manquant à schema.sql. il faudrait mettre en place un système de migration
* Changement du message d'erreur pour la connection à la BD
